### PR TITLE
fix(fcitx5-osk): protocol error on wlroots based compositors

### DIFF
--- a/fcitx5-osk/src/app/wayland/output.rs
+++ b/fcitx5-osk/src/app/wayland/output.rs
@@ -523,7 +523,15 @@ impl Dispatch<WlRegistry, ()> for OutputListener {
                         "Create a layer shell surface[{:?}] to monitor the change of geometry",
                         layer_shell_surface
                     );
-                    layer_shell_surface.set_anchor(Anchor::Top | Anchor::Left);
+                    // The size is left at the default 0x0, and set_size requires a
+                    // dimension left at 0 to be anchored to opposite edges, so anchoring
+                    // all four is mandatory here. Kwin tolerates Top | Left, but wlroots
+                    // based compositors raise invalid_size on commit, killing the
+                    // connection and aborting at startup. Anchoring all four edges also
+                    // makes the configure event report the usable area, which is what
+                    // logical_width/logical_height want.
+                    layer_shell_surface
+                        .set_anchor(Anchor::Top | Anchor::Bottom | Anchor::Left | Anchor::Right);
                     // Make events pass through the window
                     let region = state.compositer.create_region(qh, ());
                     surface.set_input_region(Some(&region));


### PR DESCRIPTION
On niri, `fcitx5-osk keyboard` aborts right at startup:

```
zwlr_layer_surface_v1#21: error 1: width 0 requested without setting left and right anchors
Protocol error 1 on object zwlr_layer_surface_v1@21
thread panicked at iced_layershell-0.16.0/src/multi_window.rs:113:10:
Cannot create layershell: DispatchError(Backend(Protocol(ProtocolError { code: 1, object_id: 21, object_interface: "zwlr_layer_surface_v1" })))
```

Object 21 is the "TRANSPARENT" surface created per output in `output.rs` to watch the geometry. It is committed without a size and anchored to Top | Left, and `set_size` says a dimension left at 0 must be anchored to opposite edges. Kwin lets it through, wlroots based compositors reject it on commit. The panic shows up in layershellev because the connection is shared with it, so the whole process goes down.

Anchoring all four edges keeps the 0x0 size legal, and the configure event then reports the usable area rather than the full output, which is what the comment on `logical_width` asks for.

I first tried `set_size(1, 1)` instead. It stops the crash but breaks the geometry monitor: the screen size comes back as 1x1 and the keyboard never opens.

Reproduced with an empty `XDG_CONFIG_HOME` on niri 26.04, fcitx5 5.1.21. Been running the patched build here all day.